### PR TITLE
Set json as default format for tastypie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 Django Backbone Example
 -----------------------
 
-This is an example application using Django, with the help of [django-tastypie](https://github.com/toastdriven/django-tastypie), and [backbone.js](https://github.com/documentcloud/backbone). Because everyone needs to write a Twitter clone, it is a Twitter clone. 
+This is an example application using Django, with the help of [django-tastypie](https://github.com/toastdriven/django-tastypie), and [backbone.js](https://github.com/documentcloud/backbone). Because everyone needs to write a Twitter clone, it is a Twitter clone.
 
 
 Running locally
 ---------------
 
-Preferably in a virtualenv, run the following commands: 
+Preferably in a virtualenv, run the following commands:
 
-    git clone https://joshbohde@github.com/joshbohde/django-backbone-example.git
-    cd backbone_example
+    git clone https://github.com/joshbohde/django-backbone-example.git
+    cd django-backbone-example/backbone_example
     pip install -r requirements.txt
     ./manage.py syncdb --noinput
     ./manage.py runserver
-    
+

--- a/backbone_example/tweets/api/resources.py
+++ b/backbone_example/tweets/api/resources.py
@@ -3,9 +3,13 @@ from tastypie.authorization import Authorization
 
 from tweets.models import Tweet
 
+
 class TweetResource(ModelResource):
     class Meta:
         queryset = Tweet.objects.all()
         authorization = Authorization()
         list_allowed_methods = ['get', 'post']
         detail_allowed_methods = ['get']
+
+    def determine_format(self, request):
+        return "application/json"


### PR DESCRIPTION
Set json as default format for tastypie in order to not receive the error:

_Sorry, not implemented yet. Please append "?format=json" to your URL._
